### PR TITLE
ChatSpaceアプリのデータベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,39 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# DataBase設計
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+
+### Association
+- has_many :groups_users
+- has_many :groups, through: :groups_users 
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string| |
+|group_id|integer|null: false|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :groups_users
+- has_many :users, through: :groups_users
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### Association
 - has_many :groups_users
-- has_many :groups, through: :groups_users 
+- has_many :groups, through: groups_users 
 - has_many :messages
 
 ## groupsテーブル
@@ -19,7 +19,7 @@
 
 ### Association
 - has_many :groups_users
-- has_many :users, through: :groups_users
+- has_many :users, through: groups_users
 - has_many :messages
 
 ## messagesテーブル

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### Association
 - has_many :groups_users
-- has_many :groups, through: groups_users 
+- has_many :groups, through: :groups_users 
 - has_many :messages
 
 ## groupsテーブル
@@ -19,7 +19,7 @@
 
 ### Association
 - has_many :groups_users
-- has_many :users, through: groups_users
+- has_many :users, through: :groups_users
 - has_many :messages
 
 ## messagesテーブル
@@ -27,8 +27,8 @@
 |------|----|-------|
 |body|text|null: false|
 |image|string| |
-|group_id|integer|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -10,18 +10,29 @@
 ### Association
 - has_many :groups_users
 - has_many :groups, through: :groups_users 
+- has_many :messages
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
-|image|string| |
-|group_id|integer|null: false|
-|user_id|integer|null: false, foreign_key: true|
+|group_name|string|null: false|
 
 ### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users
+- has_many :messages
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string| |
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
 
 ## groups_usersテーブル
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,3 @@
-# README
-
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
-
 # DataBase設計
 
 ## usersテーブル

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :groups_users
@@ -25,10 +25,10 @@
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text| |
 |image|string| |
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -38,8 +38,8 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group


### PR DESCRIPTION
# What
ChatSpaceのデータベースの設計をする。
usersテーブルとgroupsテーブルは多対多の関係のため、中間テーブルgroups_usersテーブルを作成し一対多の関係のアソシエーションを記載しています。
usersテーブルとgroupsテーブル共にmessagesテーブルに対しては、一対多の関係のアソシエーションを記載しています。

# Why
ChatSpaceアプリ作成にあたり、データベースの設計を可視化することで他メンバーとの情報共有を行うため。