### PR TITLE
メインヘッダーの実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,8 @@
 class UsersController < ApplicationController
 
+  def index
+  end
+
   def edit
   end
 

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,10 +2,12 @@
   .group-summary
     .group-summary__box
       %p.group-summary__box__group
-        test
+        = @group.name
       %p.group-summary__box__member
-        Member：masa
-    = link_to "#", class: "group-summary__btn" do
+        Member:
+        - @group.group_users.each do |group_user|
+          = group_user.user.name
+    = link_to 'edit', class: "group-summary__btn" do
       Edit
 
   .messages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index,:edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# Why
ChatSpaceのメイン画面のヘッダーのグループ名とメンバーを仮置きのテキストから現在のグループ名及びグループに属しているメンバーの表示にする。また、ヘッダー右側のEditボタンを押すとグループ編集ページに移行させる。

# What
ChatSpaceアプリの仕様として現在のグループ名とメンバーをメイン画面のヘッダーへの表示内容が正しいか、またEditボタンを押した時に正しくグループ編集画面に移行するか確認のため