### PR TITLE
グループ編集後のルーティング変更

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group.id), notice: 'グループを更新しました'
     else
       render :edit
     end
@@ -36,3 +36,4 @@ class GroupsController < ApplicationController
     params.require(:group).permit(:name, user_ids: [])
   end
 end
+


### PR DESCRIPTION
# What
現在のChatSpaceでは、グループ編集後に更新ボタンを押すとトップページに移動する。
移動先をトップページから編集したグループ一覧に変更する。

# Why
変更先にルーティング先が正しいのか確認するため